### PR TITLE
Add payment fee split

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,18 +88,24 @@ Sends a payment to a receiver.
 
 Sends the token of path at the last position (`path[path.length-1]`) for the amount at index 1 (`amounts[1]`) to the address at the last position (`addresses[addresses.length-1]`).
 
-Can also be used to perform token sales from decentralized exchanges to the sender by setting `addresses` to `[<sender address>]`.
+Can also be used to perform token sales from decentralized exchanges by simply setting receiver to equal sender.
 
 Ethereum: [0x99F3F4685a7178F26EB4F4Ca8B75a1724F1577B9](https://etherscan.io/address/0x99f3f4685a7178f26eb4f4ca8b75a1724f1577b9)
 
 Binance Smart Chain: [0x8B127D169D232D5F3ebE1C3D06CE343FD7C1AA11](https://bscscan.com/address/0x8B127D169D232D5F3ebE1C3D06CE343FD7C1AA11)
+
+### DePayRouterV1PaymentFee01
+
+Sends a payment fee to a third-party address.
+
+Sends the token of path at the last position (`path[path.length-1]`) for the amount at index 4 (`amounts[4]`) to the address at the previous last position (`addresses[addresses.length-2]`).
 
 ### DePayRouterV1Uniswap01
 
 Swaps TOKEN_A to TOKEN_B, NATIVE to TOKEN or TOKEN to NATIVE on UniswapV2 as part of the payment.
 
 Swaps tokens according to provided `path` using the amount at 0 (`amounts[0]`) as input amount,
-the amount at index 1 (`amounts[1]`) as output amount and the amount at index 2 (`amount[2]`) as deadline.
+the amount at index 1 (`amounts[1]`) as output amount and the amount at index 2 (`amounts[2]`) as deadline.
 
 Ethereum: [0xe04b08Dfc6CaA0F4Ec523a3Ae283Ece7efE00019](https://etherscan.io/address/0xe04b08dfc6caa0f4ec523a3ae283ece7efe00019)
 
@@ -108,7 +114,7 @@ Ethereum: [0xe04b08Dfc6CaA0F4Ec523a3Ae283Ece7efE00019](https://etherscan.io/addr
 Swaps TOKEN_A to TOKEN_B, NATIVE to TOKEN or TOKEN to NATIVE on Pancakeswap as part of the payment.
 
 Swaps tokens according to provided `path` using the amount at 0 (`amounts[0]`) as input amount,
-the amount at index 1 (`amounts[1]`) as output amount and the amount at index 2 (`amount[2]`) as deadline.
+the amount at index 1 (`amounts[1]`) as output amount and the amount at index 2 (`amounts[2]`) as deadline.
 
 Binance Smart Chain: [0xAC3Ec4e420DD78bA86d932501E1f3867dbbfb77B](https://bscscan.com/address/0xAC3Ec4e420DD78bA86d932501E1f3867dbbfb77B)
 
@@ -125,9 +131,7 @@ We do packing in `amounts[2]`. We use 256 bits to store `fee` (`fee` is used to 
 [sqrtPriceLimitX96: uint160] [reversed: 72 bits] [fee: uint24]
 ```
 
-The amount at index 3 (`amount[3]`) is the deadline of the swap.
-
-Ethereum: [XXX](XXX)
+The amount at index 3 (`amounts[3]`) is the deadline of the swap.
 
 ### DePayRouterV1CurveFiSwap01
 
@@ -158,7 +162,7 @@ Ethereum: [0xcac512f9a8599d251117d18b72a91cd5b2219a95](https://etherscan.io/addr
 Swaps TOKEN_A to TOKEN_B, NATIVE to TOKEN or TOKEN to NATIVE on SuhiSwap (based on Uniswap) as part of the payment.
 
 Swaps tokens according to provided `path` using the amount at index 0 (`amounts[0]`) as input amount,
-the amount at index 1 (`amounts[1]`) as output amount and the amount at index 2 (`amount[2]`) as deadline.
+the amount at index 1 (`amounts[1]`) as output amount and the amount at index 2 (`amounts[2]`) as deadline.
 
 Ethereum: [0xd617fdc26d762ade48Ff54c2E1DE148BFB3F9D22](https://etherscan.io/address/0xd617fdc26d762ade48ff54c2e1de148bfb3f9d22)
 
@@ -167,7 +171,7 @@ Ethereum: [0xd617fdc26d762ade48Ff54c2E1DE148BFB3F9D22](https://etherscan.io/addr
 Swaps TOKEN_A to TOKEN_B, NATIVE to TOKEN or TOKEN to NATIVE on OneSplitSwap (1Inch Protocol).
 
 Swaps tokens according to provided `path` using the amount at index 0 (`amounts[0]`) as input amount,
-the amount at index 1 (`amounts[1]`) as output amount and the amount at index 2 (`amount[2]`) as flags of 1Inch Protocol.
+the amount at index 1 (`amounts[1]`) as output amount and the amount at index 2 (`amounts[2]`) as flags of 1Inch Protocol.
 
 The rest of remaining elements of `amounts[]` is distribution of 1Inch Protocol.
 

--- a/contracts/DePayRouterV1PaymentFee01.sol
+++ b/contracts/DePayRouterV1PaymentFee01.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.6 <0.9.0;
+pragma abicoder v2;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import './libraries/Helper.sol';
+
+contract DePayRouterV1PaymentFee01 {
+
+  // Address representating ETH (e.g. in payment routing paths)
+  address public constant ETH = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+  // Indicates that this plugin requires delegate call
+  bool public immutable delegate = true;
+
+  function execute(
+    address[] calldata path,
+    uint[] calldata amounts,
+    address[] calldata addresses,
+    string[] calldata data
+  ) external payable returns(bool) {
+
+    if(path[path.length-1] == ETH) {
+      Helper.safeTransferETH(payable(addresses[addresses.length-2]), amounts[4]);
+    } else {
+      Helper.safeTransfer(path[path.length-1], payable(addresses[addresses.length-2]), amounts[4]);
+    }
+
+    return true;
+  }
+}

--- a/flatten/DePayRouterV1PaymentFee01.sol
+++ b/flatten/DePayRouterV1PaymentFee01.sol
@@ -1,0 +1,173 @@
+// Dependency file: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/libraries/Helper.sol
+
+
+// pragma solidity >=0.8.6 <0.9.0;
+
+// Helper methods for interacting with ERC20 tokens and sending ETH that do not consistently return true/false
+
+library Helper {
+  function safeApprove(
+    address token,
+    address to,
+    uint256 value
+  ) internal {
+    // bytes4(keccak256(bytes('approve(address,uint256)')));
+    (bool success, bytes memory data) = token.call(abi.encodeWithSelector(0x095ea7b3, to, value));
+    require(
+      success && (data.length == 0 || abi.decode(data, (bool))),
+      'Helper::safeApprove: approve failed'
+    );
+  }
+
+  function safeTransfer(
+    address token,
+    address to,
+    uint256 value
+  ) internal {
+    // bytes4(keccak256(bytes('transfer(address,uint256)')));
+    (bool success, bytes memory data) = token.call(abi.encodeWithSelector(0xa9059cbb, to, value));
+    require(
+      success && (data.length == 0 || abi.decode(data, (bool))),
+      'Helper::safeTransfer: transfer failed'
+    );
+  }
+
+  function safeTransferFrom(
+    address token,
+    address from,
+    address to,
+    uint256 value
+  ) internal {
+    // bytes4(keccak256(bytes('transferFrom(address,address,uint256)')));
+    (bool success, bytes memory data) = token.call(abi.encodeWithSelector(0x23b872dd, from, to, value));
+    require(
+      success && (data.length == 0 || abi.decode(data, (bool))),
+      'Helper::transferFrom: transferFrom failed'
+    );
+  }
+
+  function safeTransferETH(address to, uint256 value) internal {
+    (bool success, ) = to.call{value: value}(new bytes(0));
+    require(success, 'Helper::safeTransferETH: ETH transfer failed');
+  }
+}
+
+
+// Root file: contracts/DePayRouterV1PaymentFee01.sol
+
+
+pragma solidity >=0.8.6 <0.9.0;
+pragma abicoder v2;
+
+// import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// import 'contracts/libraries/Helper.sol';
+
+contract DePayRouterV1PaymentFee01 {
+
+  // Address representating ETH (e.g. in payment routing paths)
+  address public constant ETH = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+  // Indicates that this plugin requires delegate call
+  bool public immutable delegate = true;
+
+  function execute(
+    address[] calldata path,
+    uint[] calldata amounts,
+    address[] calldata addresses,
+    string[] calldata data
+  ) external payable returns(bool) {
+
+    if(path[path.length-1] == ETH) {
+      Helper.safeTransferETH(payable(addresses[addresses.length-2]), amounts[4]);
+    } else {
+      Helper.safeTransfer(path[path.length-1], payable(addresses[addresses.length-2]), amounts[4]);
+    }
+
+    return true;
+  }
+}

--- a/test/bsc/DePayRouterV1PaymentFee01.spec.ts
+++ b/test/bsc/DePayRouterV1PaymentFee01.spec.ts
@@ -1,0 +1,139 @@
+import deployConfiguration from '../helpers/deploy/configuration'
+import deployRouter from '../helpers/deploy/router'
+import deployTestToken from '../helpers/deploy/testToken'
+import { CONSTANTS } from 'depay-web3-constants'
+import { ethers } from 'hardhat'
+import { expect } from 'chai'
+
+const blockchain = 'bsc'
+
+describe(`DePayRouterV1PaymentFee01 on ${blockchain}`, function() {
+
+  let wallets,
+      configuration,
+      router,
+      paymentPlugin,
+      paymentFeePlugin
+
+  beforeEach(async ()=>{
+    wallets = await ethers.getSigners()
+  })
+
+  it('requires the router', async () => {
+    configuration = await deployConfiguration()
+    router = await deployRouter(configuration.address)
+  })
+
+  it('requires the paymentPlugin', async () => {
+    const Plugin = await ethers.getContractFactory('DePayRouterV1Payment01')
+    paymentPlugin = await Plugin.deploy()
+    await paymentPlugin.deployed()
+    await configuration.connect(wallets[0]).approvePlugin(paymentPlugin.address)
+  })
+
+  it('deploys the plugin', async () => {
+    const Plugin = await ethers.getContractFactory('DePayRouterV1PaymentFee01')
+    paymentFeePlugin = await Plugin.deploy()
+    await paymentFeePlugin.deployed()
+  })
+
+  it('approves the plugin', async () => {
+    await configuration.connect(wallets[0]).approvePlugin(paymentFeePlugin.address)
+  })
+
+  it('splits the payment for a received token and sends a fee to a third party', async () => {
+    let testToken = await deployTestToken()
+    let payedAmount = ethers.utils.parseUnits('1000', 18)
+    let fee = ethers.utils.parseUnits('30', 18)
+    let totalAmount = ethers.utils.parseUnits('1030', 18)
+    let sender = wallets[0]
+    let paymentReceiver = wallets[1]
+    let thirdPartyFeeReceiver = wallets[2]
+    await testToken.connect(sender).approve(router.address, CONSTANTS[blockchain].MAXINT)
+
+    await expect(()=>
+      expect(()=>
+        expect(()=>
+          router.connect(sender).route(
+            [testToken.address], // path
+            [totalAmount, payedAmount, 0, 0, fee], // amounts
+            [sender.address, thirdPartyFeeReceiver.address, paymentReceiver.address], // addresses
+            [paymentFeePlugin.address, paymentPlugin.address], // plugins
+            [] // data
+          )
+        ).to.changeTokenBalance(testToken, paymentReceiver, ethers.utils.parseUnits('1000', 18))
+      ).to.changeTokenBalance(testToken, thirdPartyFeeReceiver, ethers.utils.parseUnits('30', 18))
+    ).to.changeTokenBalance(testToken, sender, ethers.utils.parseUnits('-1030', 18))
+  })
+
+  it('splits the payment for received NATIVE currency and sends a fee to a third party', async () => {
+    let payedAmount = ethers.utils.parseUnits('1.1', 18)
+    let fee = ethers.utils.parseUnits('0.3', 18)
+    let totalAmount = ethers.utils.parseUnits('1.4', 18)
+    let sender = wallets[0]
+    let paymentReceiver = wallets[1]
+    let thirdPartyFeeReceiver = wallets[2]
+
+    let transaction = await router.connect(sender).route(
+      [CONSTANTS[blockchain].NATIVE], // path
+      [totalAmount, payedAmount, 0, 0, fee], // amounts
+      [sender.address, thirdPartyFeeReceiver.address, paymentReceiver.address], // addresses
+      [paymentFeePlugin.address, paymentPlugin.address], // plugins
+      [], // data
+      { value: totalAmount }
+    )
+    
+    expect(transaction).to.changeEtherBalance(paymentReceiver, ethers.utils.parseUnits('1.1', 18))
+    expect(transaction).to.changeEtherBalance(thirdPartyFeeReceiver, ethers.utils.parseUnits('0.3', 18))
+    expect(transaction).to.changeEtherBalance(sender, ethers.utils.parseUnits('-1.4', 18))
+  })
+
+  it('fails and reverts if fee+payment is higher than amount payed in for NATIVE currency', async () => {
+    let payedAmount = ethers.utils.parseUnits('1.1', 18)
+    let fee = ethers.utils.parseUnits('0.3', 18)
+    let totalAmount = ethers.utils.parseUnits('1.4', 18)
+    let sender = wallets[0]
+    let paymentReceiver = wallets[1]
+    let thirdPartyFeeReceiver = wallets[2]
+    let amountPaidIn = totalAmount.sub(ethers.utils.parseUnits('0.1', 18))
+    await wallets[3].sendTransaction({ to: router.address, value: ethers.utils.parseUnits('0.1', 18) })
+
+    await expect(
+      router.connect(sender).route(
+        [CONSTANTS[blockchain].NATIVE], // path
+        [amountPaidIn, payedAmount, 0, 0, fee], // amounts
+        [sender.address, thirdPartyFeeReceiver.address, paymentReceiver.address], // addresses
+        [paymentFeePlugin.address, paymentPlugin.address], // plugins
+        [], // data
+        { value: amountPaidIn }
+      )
+    ).to.be.revertedWith(
+      'DePay: Insufficient balance after payment!'
+    )
+  })
+
+  it('fails and reverts if fee+payment is higher than amount payed in for token', async () => {
+    let testToken = await deployTestToken()
+    let payedAmount = ethers.utils.parseUnits('1000', 18)
+    let fee = ethers.utils.parseUnits('30', 18)
+    let totalAmount = ethers.utils.parseUnits('1030', 18)
+    let amountPaidIn = totalAmount.sub(ethers.utils.parseUnits('10', 18))
+    let sender = wallets[0]
+    let paymentReceiver = wallets[1]
+    let thirdPartyFeeReceiver = wallets[2]
+    await testToken.connect(sender).approve(router.address, CONSTANTS[blockchain].MAXINT)
+    await testToken.connect(sender).transfer(router.address, ethers.utils.parseUnits('10', 18))
+
+    await expect(
+      router.connect(sender).route(
+        [testToken.address], // path
+        [amountPaidIn, payedAmount, 0, 0, fee], // amounts
+        [sender.address, thirdPartyFeeReceiver.address, paymentReceiver.address], // addresses
+        [paymentFeePlugin.address, paymentPlugin.address], // plugins
+        [] // data
+      )
+    ).to.be.revertedWith(
+      'DePay: Insufficient balance after payment!'
+    )
+  })
+})

--- a/test/ethereum/DePayRouterV1PaymentFee01.spec.ts
+++ b/test/ethereum/DePayRouterV1PaymentFee01.spec.ts
@@ -1,0 +1,139 @@
+import deployConfiguration from '../helpers/deploy/configuration'
+import deployRouter from '../helpers/deploy/router'
+import deployTestToken from '../helpers/deploy/testToken'
+import { CONSTANTS } from 'depay-web3-constants'
+import { ethers } from 'hardhat'
+import { expect } from 'chai'
+
+const blockchain = 'ethereum'
+
+describe(`DePayRouterV1PaymentFee01 on ${blockchain}`, function() {
+
+  let wallets,
+      configuration,
+      router,
+      paymentPlugin,
+      paymentFeePlugin
+
+  beforeEach(async ()=>{
+    wallets = await ethers.getSigners()
+  })
+
+  it('requires the router', async () => {
+    configuration = await deployConfiguration()
+    router = await deployRouter(configuration.address)
+  })
+
+  it('requires the paymentPlugin', async () => {
+    const Plugin = await ethers.getContractFactory('DePayRouterV1Payment01')
+    paymentPlugin = await Plugin.deploy()
+    await paymentPlugin.deployed()
+    await configuration.connect(wallets[0]).approvePlugin(paymentPlugin.address)
+  })
+
+  it('deploys the plugin', async () => {
+    const Plugin = await ethers.getContractFactory('DePayRouterV1PaymentFee01')
+    paymentFeePlugin = await Plugin.deploy()
+    await paymentFeePlugin.deployed()
+  })
+
+  it('approves the plugin', async () => {
+    await configuration.connect(wallets[0]).approvePlugin(paymentFeePlugin.address)
+  })
+
+  it('splits the payment for a received token and sends a fee to a third party', async () => {
+    let testToken = await deployTestToken()
+    let payedAmount = ethers.utils.parseUnits('1000', 18)
+    let fee = ethers.utils.parseUnits('30', 18)
+    let totalAmount = ethers.utils.parseUnits('1030', 18)
+    let sender = wallets[0]
+    let paymentReceiver = wallets[1]
+    let thirdPartyFeeReceiver = wallets[2]
+    await testToken.connect(sender).approve(router.address, CONSTANTS[blockchain].MAXINT)
+
+    await expect(()=>
+      expect(()=>
+        expect(()=>
+          router.connect(sender).route(
+            [testToken.address], // path
+            [totalAmount, payedAmount, 0, 0, fee], // amounts
+            [sender.address, thirdPartyFeeReceiver.address, paymentReceiver.address], // addresses
+            [paymentFeePlugin.address, paymentPlugin.address], // plugins
+            [] // data
+          )
+        ).to.changeTokenBalance(testToken, paymentReceiver, ethers.utils.parseUnits('1000', 18))
+      ).to.changeTokenBalance(testToken, thirdPartyFeeReceiver, ethers.utils.parseUnits('30', 18))
+    ).to.changeTokenBalance(testToken, sender, ethers.utils.parseUnits('-1030', 18))
+  })
+
+  it('splits the payment for received NATIVE currency and sends a fee to a third party', async () => {
+    let payedAmount = ethers.utils.parseUnits('1.1', 18)
+    let fee = ethers.utils.parseUnits('0.3', 18)
+    let totalAmount = ethers.utils.parseUnits('1.4', 18)
+    let sender = wallets[0]
+    let paymentReceiver = wallets[1]
+    let thirdPartyFeeReceiver = wallets[2]
+
+    let transaction = await router.connect(sender).route(
+      [CONSTANTS[blockchain].NATIVE], // path
+      [totalAmount, payedAmount, 0, 0, fee], // amounts
+      [sender.address, thirdPartyFeeReceiver.address, paymentReceiver.address], // addresses
+      [paymentFeePlugin.address, paymentPlugin.address], // plugins
+      [], // data
+      { value: totalAmount }
+    )
+    
+    expect(transaction).to.changeEtherBalance(paymentReceiver, ethers.utils.parseUnits('1.1', 18))
+    expect(transaction).to.changeEtherBalance(thirdPartyFeeReceiver, ethers.utils.parseUnits('0.3', 18))
+    expect(transaction).to.changeEtherBalance(sender, ethers.utils.parseUnits('-1.4', 18))
+  })
+
+  it('fails and reverts if fee+payment is higher than amount payed in for NATIVE currency', async () => {
+    let payedAmount = ethers.utils.parseUnits('1.1', 18)
+    let fee = ethers.utils.parseUnits('0.3', 18)
+    let totalAmount = ethers.utils.parseUnits('1.4', 18)
+    let sender = wallets[0]
+    let paymentReceiver = wallets[1]
+    let thirdPartyFeeReceiver = wallets[2]
+    let amountPaidIn = totalAmount.sub(ethers.utils.parseUnits('0.1', 18))
+    await wallets[3].sendTransaction({ to: router.address, value: ethers.utils.parseUnits('0.1', 18) })
+
+    await expect(
+      router.connect(sender).route(
+        [CONSTANTS[blockchain].NATIVE], // path
+        [amountPaidIn, payedAmount, 0, 0, fee], // amounts
+        [sender.address, thirdPartyFeeReceiver.address, paymentReceiver.address], // addresses
+        [paymentFeePlugin.address, paymentPlugin.address], // plugins
+        [], // data
+        { value: amountPaidIn }
+      )
+    ).to.be.revertedWith(
+      'DePay: Insufficient balance after payment!'
+    )
+  })
+
+  it('fails and reverts if fee+payment is higher than amount payed in for token', async () => {
+    let testToken = await deployTestToken()
+    let payedAmount = ethers.utils.parseUnits('1000', 18)
+    let fee = ethers.utils.parseUnits('30', 18)
+    let totalAmount = ethers.utils.parseUnits('1030', 18)
+    let amountPaidIn = totalAmount.sub(ethers.utils.parseUnits('10', 18))
+    let sender = wallets[0]
+    let paymentReceiver = wallets[1]
+    let thirdPartyFeeReceiver = wallets[2]
+    await testToken.connect(sender).approve(router.address, CONSTANTS[blockchain].MAXINT)
+    await testToken.connect(sender).transfer(router.address, ethers.utils.parseUnits('10', 18))
+
+    await expect(
+      router.connect(sender).route(
+        [testToken.address], // path
+        [amountPaidIn, payedAmount, 0, 0, fee], // amounts
+        [sender.address, thirdPartyFeeReceiver.address, paymentReceiver.address], // addresses
+        [paymentFeePlugin.address, paymentPlugin.address], // plugins
+        [] // data
+      )
+    ).to.be.revertedWith(
+      'DePay: Insufficient balance after payment!'
+    )
+  })
+})


### PR DESCRIPTION
### DePayRouterV1PaymentFee01

Sends a payment fee to a third-party address.

Sends the token of path at the last position (`path[path.length-1]`) for the amount at index 4 (`amounts[4]`) to the address at the previous last position (`addresses[addresses.length-2]`).